### PR TITLE
Add region screenshot capture to terminal title bars

### DIFF
--- a/client/components/TerminalWindow.tsx
+++ b/client/components/TerminalWindow.tsx
@@ -41,6 +41,8 @@ export default function TerminalWindow({ tw, token, scale, onZoom, onOpenFile }:
   const [closeHovered, setCloseHovered] = useState(false);
   const [connectorHovered, setConnectorHovered] = useState(false);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [captureState, setCaptureState] = useState<'idle' | 'capturing' | 'error'>('idle');
+  const [captureHovered, setCaptureHovered] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
 
   const isBrowser = tw.type === 'browser';
@@ -148,6 +150,20 @@ export default function TerminalWindow({ tw, token, scale, onZoom, onOpenFile }:
     updateTerminal(tw.id, { url, title: url.replace(/^https?:\/\//, '').split('/')[0] || url });
     saveLayout();
   }, [tw.id, updateTerminal, saveLayout]);
+
+  const onCaptureClick = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (captureState === 'capturing') return;
+    setCaptureState('capturing');
+    try {
+      const res = await fetch(`/api/terminals/${tw.sessionId}/screenshot`, { method: 'POST' });
+      if (!res.ok) throw new Error(String(res.status));
+      setCaptureState('idle');
+    } catch {
+      setCaptureState('error');
+      setTimeout(() => setCaptureState('idle'), 1200);
+    }
+  }, [tw.sessionId, captureState]);
 
   // Link connector: start drag
   const onStartConnector = useCallback(
@@ -362,8 +378,53 @@ export default function TerminalWindow({ tw, token, scale, onZoom, onOpenFile }:
             )}
           </div>
 
-          {/* Right spacer to balance the close button */}
-          <div style={{ width: 12 }} />
+          {/* Right: capture button for terminal panels, spacer otherwise */}
+          {!isBrowser && !isExplorer && !isEditor && !isMemo ? (
+            <button
+              onClick={onCaptureClick}
+              onMouseDown={(e) => e.stopPropagation()}
+              onMouseEnter={() => setCaptureHovered(true)}
+              onMouseLeave={() => setCaptureHovered(false)}
+              title="Capture screen region and attach (Win+Shift+S)"
+              aria-label="Capture screen region"
+              disabled={captureState === 'capturing'}
+              style={{
+                width: 18,
+                height: 18,
+                padding: 0,
+                border: 'none',
+                background: 'transparent',
+                cursor: captureState === 'capturing' ? 'progress' : 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color:
+                  captureState === 'error'
+                    ? 'var(--accent-red)'
+                    : captureState === 'capturing'
+                    ? '#e0af68'
+                    : captureHovered
+                    ? 'var(--text-secondary)'
+                    : 'var(--text-tertiary)',
+                opacity: captureState === 'capturing' ? 0.9 : isActive || isHovered ? 1 : 0.6,
+                transition: 'color var(--duration-fast), opacity var(--duration-fast)',
+                animation: captureState === 'capturing' ? 'breathe 1.2s ease-in-out infinite' : undefined,
+              }}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M4 7h3l2-2h6l2 2h3a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1Z"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinejoin="round"
+                  fill="none"
+                />
+                <circle cx="12" cy="13" r="3.2" stroke="currentColor" strokeWidth="1.6" fill="none" />
+              </svg>
+            </button>
+          ) : (
+            <div style={{ width: 12 }} />
+          )}
         </div>
 
         {/* Content */}

--- a/client/components/TerminalWindow.tsx
+++ b/client/components/TerminalWindow.tsx
@@ -43,6 +43,7 @@ export default function TerminalWindow({ tw, token, scale, onZoom, onOpenFile }:
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [captureState, setCaptureState] = useState<'idle' | 'capturing' | 'error'>('idle');
   const [captureHovered, setCaptureHovered] = useState(false);
+  const [captureError, setCaptureError] = useState<string>('');
   const titleInputRef = useRef<HTMLInputElement>(null);
 
   const isBrowser = tw.type === 'browser';
@@ -155,13 +156,23 @@ export default function TerminalWindow({ tw, token, scale, onZoom, onOpenFile }:
     e.stopPropagation();
     if (captureState === 'capturing') return;
     setCaptureState('capturing');
+    setCaptureError('');
     try {
       const res = await fetch(`/api/terminals/${tw.sessionId}/screenshot`, { method: 'POST' });
-      if (!res.ok) throw new Error(String(res.status));
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = await res.json();
+          if (body?.error) detail = body.error;
+          if (body?.code === 'CANCELED') detail = 'Canceled';
+        } catch {}
+        throw new Error(detail);
+      }
       setCaptureState('idle');
-    } catch {
+    } catch (err) {
+      setCaptureError(err instanceof Error ? err.message : String(err));
       setCaptureState('error');
-      setTimeout(() => setCaptureState('idle'), 1200);
+      setTimeout(() => { setCaptureState('idle'); setCaptureError(''); }, 2000);
     }
   }, [tw.sessionId, captureState]);
 
@@ -385,7 +396,7 @@ export default function TerminalWindow({ tw, token, scale, onZoom, onOpenFile }:
               onMouseDown={(e) => e.stopPropagation()}
               onMouseEnter={() => setCaptureHovered(true)}
               onMouseLeave={() => setCaptureHovered(false)}
-              title="Capture screen region and attach (Win+Shift+S)"
+              title={captureError || 'Capture screen region and attach (Win+Shift+S)'}
               aria-label="Capture screen region"
               disabled={captureState === 'capturing'}
               style={{

--- a/server/index.ts
+++ b/server/index.ts
@@ -154,6 +154,10 @@ app.get('/api/screenshot/capabilities', (_req, res) => {
   res.json({ supported: canCaptureScreen() });
 });
 
+// Per-session guard: at most one capture in flight per terminal. Prevents the
+// double-click race where two PS children fight over the Windows clipboard.
+const inflightCaptures = new Set<string>();
+
 // Capture a screen region via the native Windows snip UI, save the PNG into
 // the terminal's CWD, and paste the resulting path into the terminal's PTY.
 app.post('/api/terminals/:sessionId/screenshot', async (req, res) => {
@@ -166,19 +170,29 @@ app.post('/api/terminals/:sessionId/screenshot', async (req, res) => {
     res.status(501).json({ error: 'Screen capture requires Windows or WSL' });
     return;
   }
+  if (inflightCaptures.has(resolved)) {
+    res.status(409).json({ error: 'Capture already in progress for this terminal', code: 'BUSY' });
+    return;
+  }
+  inflightCaptures.add(resolved);
 
   try {
     const png = await captureRegionPng();
 
+    // Re-check session liveness — user may have closed the terminal mid-capture.
     const status = ptyManager.getSessionStatus(resolved);
-    const isWindowsShell = status?.shellType === 'windows';
-    const linuxCwd = status?.cwd;
+    if (!status) {
+      res.status(410).json({ error: 'Session closed during capture', code: 'GONE' });
+      return;
+    }
+    const isWindowsShell = status.shellType === 'windows';
+    const linuxCwd = status.cwd;
 
     // Save location: terminal's CWD when known (WSL/Linux/macOS). For a
     // Windows-shell terminal (CWD not reliably obtainable), fall back to
     // the system tmpdir.
     const saveDir = !isWindowsShell && linuxCwd && existsSync(linuxCwd) ? linuxCwd : tmpdir();
-    const ts = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19);
+    const ts = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 23);
     const filename = `screenshot-${ts}.png`;
     const savedPath = join(saveDir, filename);
     writeFileSync(savedPath, png);
@@ -199,11 +213,18 @@ app.post('/api/terminals/:sessionId/screenshot', async (req, res) => {
     res.json({ ok: true, path: savedPath, pastedAs: pasted });
   } catch (err) {
     if (err instanceof ScreenshotError) {
-      const statusCode = err.code === 'TIMEOUT' ? 408 : err.code === 'UNSUPPORTED' ? 501 : 500;
+      const statusCode =
+        err.code === 'CANCELED' ? 499 :
+        err.code === 'TIMEOUT' ? 408 :
+        err.code === 'UNSUPPORTED' ? 501 :
+        err.code === 'LAUNCH_FAILED' ? 503 :
+        500;
       res.status(statusCode).json({ error: err.message, code: err.code });
     } else {
       res.status(500).json({ error: String(err) });
     }
+  } finally {
+    inflightCaptures.delete(resolved);
   }
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { existsSync, writeFileSync, readdirSync, readFileSync, statSync, renameSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { PtyManager, type NotificationEntry } from './pty-manager.js';
+import { captureRegionPng, canCaptureScreen, wslPathToWindows, ScreenshotError } from './screenshot.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = parseInt(process.env.PORT || '3001', 10);
@@ -145,6 +146,64 @@ app.post('/api/upload', (req, res) => {
     res.json({ path: filePath });
   } catch (err) {
     res.status(500).json({ error: String(err) });
+  }
+});
+
+// Capability probe: surface whether the host can launch the region-snip UI.
+app.get('/api/screenshot/capabilities', (_req, res) => {
+  res.json({ supported: canCaptureScreen() });
+});
+
+// Capture a screen region via the native Windows snip UI, save the PNG into
+// the terminal's CWD, and paste the resulting path into the terminal's PTY.
+app.post('/api/terminals/:sessionId/screenshot', async (req, res) => {
+  const resolved = resolveSession(req.params.sessionId);
+  if (!resolved) {
+    res.status(404).json({ error: 'Session not found' });
+    return;
+  }
+  if (!canCaptureScreen()) {
+    res.status(501).json({ error: 'Screen capture requires Windows or WSL' });
+    return;
+  }
+
+  try {
+    const png = await captureRegionPng();
+
+    const status = ptyManager.getSessionStatus(resolved);
+    const isWindowsShell = status?.shellType === 'windows';
+    const linuxCwd = status?.cwd;
+
+    // Save location: terminal's CWD when known (WSL/Linux/macOS). For a
+    // Windows-shell terminal (CWD not reliably obtainable), fall back to
+    // the system tmpdir.
+    const saveDir = !isWindowsShell && linuxCwd && existsSync(linuxCwd) ? linuxCwd : tmpdir();
+    const ts = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19);
+    const filename = `screenshot-${ts}.png`;
+    const savedPath = join(saveDir, filename);
+    writeFileSync(savedPath, png);
+
+    // Paste path into the terminal. Windows-shell terminals need a Windows
+    // path; everyone else gets the POSIX path. Quote if it contains spaces.
+    let pastePath = savedPath;
+    if (isWindowsShell) {
+      const winPath = wslPathToWindows(savedPath);
+      if (winPath) pastePath = winPath;
+    }
+    const needsQuote = /\s/.test(pastePath);
+    const pasted = needsQuote
+      ? (isWindowsShell ? `"${pastePath}"` : `'${pastePath}'`)
+      : pastePath;
+    ptyManager.write(resolved, pasted);
+
+    res.json({ ok: true, path: savedPath, pastedAs: pasted });
+  } catch (err) {
+    if (err instanceof ScreenshotError) {
+      const statusCode = err.code === 'TIMEOUT' ? 408 : err.code === 'UNSUPPORTED' ? 501 : 500;
+      res.status(statusCode).json({ error: err.message, code: err.code });
+    } else {
+      res.status(500).json({ error: String(err) });
+    }
   }
 });
 

--- a/server/screenshot.ts
+++ b/server/screenshot.ts
@@ -1,0 +1,140 @@
+import { spawn, execFileSync } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { platform } from 'os';
+
+// PowerShell script: clear clipboard, trigger native region-snip UI,
+// poll clipboard for image, emit PNG bytes as base64 to stdout.
+const PS_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+try { [System.Windows.Forms.Clipboard]::Clear() } catch {}
+
+Start-Process "explorer.exe" "ms-screenclip:" -ErrorAction SilentlyContinue
+
+$deadline = [DateTime]::UtcNow.AddSeconds(60)
+$image = $null
+while ([DateTime]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 150
+    try {
+        if ([System.Windows.Forms.Clipboard]::ContainsImage()) {
+            $image = [System.Windows.Forms.Clipboard]::GetImage()
+            if ($null -ne $image) { break }
+        }
+    } catch {}
+}
+
+if ($null -eq $image) {
+    [Console]::Error.Write("TIMEOUT")
+    exit 2
+}
+
+$ms = New-Object System.IO.MemoryStream
+try {
+    $image.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+    $bytes = $ms.ToArray()
+    $stdout = [Console]::OpenStandardOutput()
+    $stdout.Write($bytes, 0, $bytes.Length)
+    $stdout.Flush()
+} finally {
+    $image.Dispose()
+    $ms.Dispose()
+    try { [System.Windows.Forms.Clipboard]::Clear() } catch {}
+}
+`;
+
+let cachedIsWSL: boolean | null = null;
+
+export function isWSL(): boolean {
+  if (cachedIsWSL !== null) return cachedIsWSL;
+  if (platform() !== 'linux') {
+    cachedIsWSL = false;
+    return false;
+  }
+  try {
+    const v = readFileSync('/proc/version', 'utf-8').toLowerCase();
+    cachedIsWSL = v.includes('microsoft') || v.includes('wsl');
+  } catch {
+    cachedIsWSL = false;
+  }
+  return cachedIsWSL;
+}
+
+export function canCaptureScreen(): boolean {
+  return platform() === 'win32' || isWSL();
+}
+
+function resolvePowershell(): string {
+  if (platform() === 'win32') return 'powershell.exe';
+  // WSL: powershell.exe should be reachable via interop PATH. If it isn't, fall
+  // back to the canonical mount path so the feature still works with
+  // appendWindowsPath=false in /etc/wsl.conf.
+  const mounted = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe';
+  if (existsSync(mounted)) return mounted;
+  return 'powershell.exe';
+}
+
+export class ScreenshotError extends Error {
+  constructor(message: string, public code: 'TIMEOUT' | 'UNSUPPORTED' | 'FAILED') {
+    super(message);
+  }
+}
+
+// Launches the native Windows region-snip UI and resolves with PNG bytes.
+// Rejects with ScreenshotError('TIMEOUT') if the user cancels or waits >60s.
+export function captureRegionPng(): Promise<Buffer> {
+  if (!canCaptureScreen()) {
+    return Promise.reject(new ScreenshotError('Screen capture requires Windows or WSL', 'UNSUPPORTED'));
+  }
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const encoded = Buffer.from(PS_SCRIPT, 'utf16le').toString('base64');
+    const child = spawn(resolvePowershell(), [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy', 'Bypass',
+      '-Sta',
+      '-EncodedCommand', encoded,
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (c) => stdoutChunks.push(c));
+    child.stderr.on('data', (c) => stderrChunks.push(c));
+
+    child.on('error', (err) => {
+      rejectPromise(new ScreenshotError(`Failed to spawn powershell: ${err.message}`, 'FAILED'));
+    });
+
+    child.on('close', (code) => {
+      if (code === 2) {
+        rejectPromise(new ScreenshotError('Capture canceled or timed out', 'TIMEOUT'));
+        return;
+      }
+      if (code !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+        rejectPromise(new ScreenshotError(`powershell exited ${code}: ${stderr.trim()}`, 'FAILED'));
+        return;
+      }
+      const png = Buffer.concat(stdoutChunks);
+      if (png.length < 8 || png[0] !== 0x89 || png[1] !== 0x50) {
+        rejectPromise(new ScreenshotError('captured payload was not a PNG', 'FAILED'));
+        return;
+      }
+      resolvePromise(png);
+    });
+  });
+}
+
+// Convert a WSL path (/home/x/foo) to a Windows path (\\wsl.localhost\...\foo).
+// Returns null on non-WSL or on conversion failure.
+export function wslPathToWindows(linuxPath: string): string | null {
+  if (!isWSL()) return null;
+  try {
+    const out = execFileSync('wslpath', ['-w', linuxPath], { encoding: 'utf-8', timeout: 2000 });
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/server/screenshot.ts
+++ b/server/screenshot.ts
@@ -2,27 +2,69 @@ import { spawn, execFileSync } from 'child_process';
 import { readFileSync, existsSync } from 'fs';
 import { platform } from 'os';
 
-// PowerShell script: clear clipboard, trigger native region-snip UI,
-// poll clipboard for image, emit PNG bytes as base64 to stdout.
+// PowerShell script: clear clipboard, trigger native region-snip UI, poll
+// clipboard for an image, emit raw PNG bytes on stdout. The snip host is
+// ScreenClippingHost.exe (Win11) or SnippingTool.exe (Win10 / fallback).
+// We watch those processes so an Escape-cancel exits fast instead of waiting
+// the full timeout. Exit 2 = timeout, 3 = canceled, 4 = launch failed.
 const PS_SCRIPT = `
 $ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+$WarningPreference = 'SilentlyContinue'
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 
 try { [System.Windows.Forms.Clipboard]::Clear() } catch {}
 
-Start-Process "explorer.exe" "ms-screenclip:" -ErrorAction SilentlyContinue
+$launched = $false
+try { Start-Process "ms-screenclip:" -ErrorAction Stop; $launched = $true } catch {}
+if (-not $launched) {
+    try { Start-Process "explorer.exe" "ms-screenclip:" -ErrorAction Stop; $launched = $true } catch {}
+}
+if (-not $launched) {
+    try { Start-Process "SnippingTool.exe" "/clip" -ErrorAction Stop; $launched = $true } catch {}
+}
+if (-not $launched) {
+    [Console]::Error.Write("LAUNCH_FAILED")
+    exit 4
+}
 
+$snipNames = @('ScreenClippingHost','SnippingTool')
 $deadline = [DateTime]::UtcNow.AddSeconds(60)
+$startupDeadline = [DateTime]::UtcNow.AddMilliseconds(1500)
+$sawSnipProcess = $false
 $image = $null
+
 while ([DateTime]::UtcNow -lt $deadline) {
-    Start-Sleep -Milliseconds 150
+    Start-Sleep -Milliseconds 120
     try {
         if ([System.Windows.Forms.Clipboard]::ContainsImage()) {
             $image = [System.Windows.Forms.Clipboard]::GetImage()
             if ($null -ne $image) { break }
         }
     } catch {}
+
+    $procAlive = $false
+    foreach ($n in $snipNames) {
+        if (Get-Process -Name $n -ErrorAction SilentlyContinue) { $procAlive = $true; break }
+    }
+    if ($procAlive) { $sawSnipProcess = $true }
+    elseif ($sawSnipProcess) {
+        # Snip UI appeared then closed without writing clipboard → canceled.
+        # Give it 400ms in case clipboard write is still propagating.
+        Start-Sleep -Milliseconds 400
+        if ([System.Windows.Forms.Clipboard]::ContainsImage()) {
+            $image = [System.Windows.Forms.Clipboard]::GetImage()
+            if ($null -ne $image) { break }
+        }
+        [Console]::Error.Write("CANCELED")
+        exit 3
+    }
+    elseif ([DateTime]::UtcNow -gt $startupDeadline) {
+        # Snip UI never appeared — launcher silently failed.
+        [Console]::Error.Write("LAUNCH_FAILED")
+        exit 4
+    }
 }
 
 if ($null -eq $image) {
@@ -75,9 +117,12 @@ function resolvePowershell(): string {
   return 'powershell.exe';
 }
 
+export type ScreenshotErrorCode = 'TIMEOUT' | 'CANCELED' | 'LAUNCH_FAILED' | 'UNSUPPORTED' | 'FAILED';
+
 export class ScreenshotError extends Error {
-  constructor(message: string, public code: 'TIMEOUT' | 'UNSUPPORTED' | 'FAILED') {
+  constructor(message: string, public code: ScreenshotErrorCode) {
     super(message);
+    this.name = 'ScreenshotError';
   }
 }
 
@@ -109,7 +154,15 @@ export function captureRegionPng(): Promise<Buffer> {
 
     child.on('close', (code) => {
       if (code === 2) {
-        rejectPromise(new ScreenshotError('Capture canceled or timed out', 'TIMEOUT'));
+        rejectPromise(new ScreenshotError('Capture timed out', 'TIMEOUT'));
+        return;
+      }
+      if (code === 3) {
+        rejectPromise(new ScreenshotError('Capture canceled', 'CANCELED'));
+        return;
+      }
+      if (code === 4) {
+        rejectPromise(new ScreenshotError('Could not launch Windows snip UI', 'LAUNCH_FAILED'));
         return;
       }
       if (code !== 0) {
@@ -118,7 +171,11 @@ export function captureRegionPng(): Promise<Buffer> {
         return;
       }
       const png = Buffer.concat(stdoutChunks);
-      if (png.length < 8 || png[0] !== 0x89 || png[1] !== 0x50) {
+      const isPng =
+        png.length >= 8 &&
+        png[0] === 0x89 && png[1] === 0x50 && png[2] === 0x4e && png[3] === 0x47 &&
+        png[4] === 0x0d && png[5] === 0x0a && png[6] === 0x1a && png[7] === 0x0a;
+      if (!isPng) {
         rejectPromise(new ScreenshotError('captured payload was not a PNG', 'FAILED'));
         return;
       }


### PR DESCRIPTION
Adds a camera button to each terminal panel that invokes the native
Windows region-snip UI (ms-screenclip:) via WSL interop, saves the
resulting PNG into the terminal's CWD, and pastes the path into the
PTY. Supports WSL and native Windows; Windows-shell terminals receive
a wslpath-converted Windows path with proper quoting.